### PR TITLE
Speed up sigscan

### DIFF
--- a/OsuManager/Memory/Processes/OsuProcess.cs
+++ b/OsuManager/Memory/Processes/OsuProcess.cs
@@ -30,17 +30,26 @@ namespace osu.Memory.Processes
             var lastOccurenceTable = generateLastOccurenceTable(parsedPattern);
             var mainModule = Process.MainModule;
 
+            const int bufferSize = 0x80000;
+            var buffer = new byte[bufferSize + parsedPattern.Bytes.Length - 1];
+
             var regions = EnumerateMemoryRegions();
             foreach (var region in regions)
             {
                 if ((uint)region.BaseAddress < (uint)mainModule.BaseAddress)
                     continue;
 
-                byte[] buffer = ReadMemory(region.BaseAddress, region.RegionSize.ToUInt32());
-                if (findMatch(parsedPattern, buffer, lastOccurenceTable, out UIntPtr match))
+                ulong start = region.BaseAddress.ToUInt64();
+                ulong end = region.BaseAddress.ToUInt64() + region.RegionSize.ToUInt64();
+                for (ulong i = start; i < end; i += bufferSize)
                 {
-                    result = (UIntPtr)(region.BaseAddress.ToUInt32() + match.ToUInt32());
-                    return true;
+                    var currentBufferLen = Math.Min((uint)buffer.Length, end - i);
+                    ReadMemory(new UIntPtr(i), buffer, (uint)currentBufferLen);
+                    if (findMatch(parsedPattern, buffer, lastOccurenceTable, out UIntPtr match, (int)currentBufferLen))
+                    {
+                        result = new UIntPtr(i + match.ToUInt64());
+                        return true;
+                    }
                 }
             }
 
@@ -120,12 +129,12 @@ namespace osu.Memory.Processes
             return table;
         }
 
-        private unsafe bool findMatch(Pattern pattern, byte[] buffer, int[] lastOccurenceTable, out UIntPtr result)
+        private unsafe bool findMatch(Pattern pattern, byte[] buffer, int[] lastOccurenceTable, out UIntPtr result, int bufferLength = -1)
         {
             result = UIntPtr.Zero;
 
             int patternLength = pattern.Bytes.Length;
-            int bufferLength = buffer.Length;
+            bufferLength = bufferLength != -1 ? bufferLength : buffer.Length;
             int patternLastIndex = patternLength - 1;
 
             fixed (int* lastOccurenceTablePtr = lastOccurenceTable)

--- a/OsuManager/Memory/Processes/OsuProcess.cs
+++ b/OsuManager/Memory/Processes/OsuProcess.cs
@@ -24,6 +24,8 @@ namespace osu.Memory.Processes
 
         public OsuProcess(Process process) => Process = process;
 
+        private List<MemoryRegion> cachedMemoryRegions;
+
         public bool FindPattern(string pattern, out UIntPtr result)
         {
             var parsedPattern = Pattern.Parse(pattern);
@@ -33,7 +35,7 @@ namespace osu.Memory.Processes
             const int bufferSize = 0x80000;
             var buffer = new byte[bufferSize + parsedPattern.Bytes.Length - 1];
 
-            var regions = EnumerateMemoryRegions();
+            var regions = cachedMemoryRegions ?? (cachedMemoryRegions = EnumerateMemoryRegions());
             foreach (var region in regions)
             {
                 if ((uint)region.BaseAddress < (uint)mainModule.BaseAddress)

--- a/OsuManager/Memory/Processes/OsuProcess.cs
+++ b/OsuManager/Memory/Processes/OsuProcess.cs
@@ -28,11 +28,12 @@ namespace osu.Memory.Processes
         {
             var parsedPattern = Pattern.Parse(pattern);
             var lastOccurenceTable = generateLastOccurenceTable(parsedPattern);
+            var mainModule = Process.MainModule;
 
             var regions = EnumerateMemoryRegions();
             foreach (var region in regions)
             {
-                if ((uint)region.BaseAddress < (uint)Process.MainModule.BaseAddress)
+                if ((uint)region.BaseAddress < (uint)mainModule.BaseAddress)
                     continue;
 
                 byte[] buffer = ReadMemory(region.BaseAddress, region.RegionSize.ToUInt32());


### PR DESCRIPTION
Some mostly minor changes, speeds up sigscan in my VM from 8.5s to 1.3s. Testing wasn't very scientific, so please test for yourself as well.

Changes:
- Lift Process.MainModule out of loop (biggest speed increase)
- Re-use a fixed-size buffer instead of reading entire memory regions at once
- Cache memory regions. Only saves a few hundred milliseconds and it fluctuated a lot, so I don't know if it had much influence.

Other possible optimizations:
- Scan for all patterns at once, so memory reading only has to be done
- Only scan the memory region the pattern can actually be in

I'm not sure why sigscan is still so slow, in my personal projects I frequently got under 20ms for 1 pattern.